### PR TITLE
grey out <iscomment> tags

### DIFF
--- a/syntax/isml.vim
+++ b/syntax/isml.vim
@@ -19,6 +19,9 @@ syn region  javaScript start=+<isscript\_[^>]*>+ keepend end=+</isscript>+me=s-1
 syn region ismlExprBlock matchgroup=ismlExprDelim start=/${-\?/ end=/-\?}/ contains=@htmlJavaScript containedin=htmlString, htmlTag
 hi link ismlExprDelim Constant
 
+syn region ismlComment start=+<iscomment>+ keepend end=+</iscomment>+ containedin=htmlString, htmlTag
+hi link ismlComment Comment
+
 syn keyword ismlTagName contained isscript iscomment iscontent isinclude isloop isredirect
 syn keyword ismlTagName contained isprint isset iscache isdecorate isif iselse iselseif
 syn keyword ismlTagName contained isreplace isslot


### PR DESCRIPTION
I have never worked on vim syntax files before, but this seems to do the trick.
The only issue I have is below, but I'm not sure how to fix it or if it is a problem with my tmux setup.  It only occurs sometimes on single line comment blocks.

![image](https://user-images.githubusercontent.com/9081154/45242399-1408af80-b2ad-11e8-9162-0e263cd79b84.png)
![image](https://user-images.githubusercontent.com/9081154/45242564-c5a7e080-b2ad-11e8-9fbf-7c933ddd6687.png)

